### PR TITLE
Update core.js

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -31,13 +31,14 @@ var
         }
     },
 
-    baron = function(params) { // this - window or jQuery instance
-        var jQueryMode = (this && this[0] && this[0].nodeType),
+    baron = function(params) {
+        var jQueryMode,
             roots,
             $;
 
         params = params || {};
         $ = params.$ || window.jQuery;
+        jQueryMode = this instanceof $;  // this - window or jQuery instance
 
         if (jQueryMode) {
             params.root = roots = this;


### PR DESCRIPTION
BugFix
Expression this && this[0] && this[0].nodeType may lead to SecurityException in following case:
1) we use baron as standalone function, so this === window
2) window contains iframe from another domain (disqus widget will be nice example), so this[0] == window[0] - is disqus window, which is in another domain
3) this[0].nodeType will lead to SecurityException
