### PR TITLE
Fixed undefined $ in dispose() method for non-jquery instances

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -623,7 +623,7 @@ var
         dispose: function(params) {
             manageEvents(this, this.event, 'off');
             manageAttr(this.root, params.direction, 'off');
-            $(this.scroller).css(this.origin.crossSize, '');
+            this.$(this.scroller).css(this.origin.crossSize, '');
             this.barOn(true);
             fire.call(this, 'dispose');
             this._disposed = true;

--- a/test/nojqueryTests.js
+++ b/test/nojqueryTests.js
@@ -60,5 +60,28 @@ describe("Барон.", function() {
             assert.ok(Math.abs(height - expectedHeight) <= 1);
         });
 
+        describe("При вызове метода dispose()", function() {
+
+            it("удаляет инстанс барона без ошибок", function() {
+                assert.doesNotThrow(function() {
+                    baronInstance.dispose();
+                }, Error);
+            });
+
+            it("удаляет атрибут data-baron-v", function() {
+                var attrV = bonzoQuery('.scroller').attr('data-baron-v'),
+                    attrH = bonzoQuery('.scroller').attr('data-baron-h');
+
+                assert.isNull(attrV);
+                assert.isNull(attrH);
+            });
+
+            it("ставит display: none для bar-ов", function() {
+                var display = bonzoQuery(bar).css('display');
+                assert.ok(display === 'none');
+            });
+
+        });
+
     });
 });


### PR DESCRIPTION
For none-jquery instances `dispose` method of baron instance throws error "undefined is not a function". Updated core and corresponding tests. 
