### PR TITLE
fix CommonJS problem

### DIFF
--- a/baron.js
+++ b/baron.js
@@ -663,7 +663,7 @@ var
     }
 
     window.baron = baron; // Use noConflict method if you need window.baron var for another purposes
-    if (window['module'] && module.exports) {
+    if (typeof module !== 'undefined' && module.exports) {
         module.exports = baron.noConflict();
     }
 })(window, window.$);


### PR DESCRIPTION
``` javascript
if (window.module && module.exports) {
  // ...
}
```

These lines of code doesn't work on duojs and component.io. They don't use `module` as a global variable.
