### PR TITLE
added scrollbar drag styling support

### DIFF
--- a/baron.js
+++ b/baron.js
@@ -155,6 +155,7 @@ var
                     e.preventDefault(); // Text selection disabling in Opera... and all other browsers?
                     item.selection(); // Disable text selection in ie8
                     item.drag.now = 1; // Save private byte
+                    $(item.bar).addClass(item.draggingCls);
                 },
 
                 type: 'touchstart mousedown'
@@ -165,6 +166,7 @@ var
                 handler: function() {
                     item.selection(1); // Enable text selection
                     item.drag.now = 0;
+                    $(item.bar).removeClass(item.draggingCls);
                 },
 
                 type: 'mouseup blur touchend'
@@ -383,6 +385,7 @@ var
             this.origin = origin[this.direction];
             this.barOnCls = params.barOnCls || '_baron';
             this.scrollingCls = params.scrollingCls;
+            this.draggingCls = params.draggingCls;
             this.barTopLimit = 0;
             pause = params.pause * 1000 || 0;
 


### PR DESCRIPTION
Added dragginCls param:
when user dragging scrollbar - this class adds to scrollbar, for best user experience and more native visualization while navigating in this manner.
(cause of without this solution when dragging scrollbar and move mouse out - it's no possible to show, that user interacts scrollbar, css :hover state and other pseudo classes not work)