### PR TITLE
get `window` property from global object

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2,7 +2,7 @@
 
 var scopedWindow = (function() {
     return this || (1, eval)('this')
-}())
+}()).window
 
 var event = require('./utils').event
 var css = require('./utils').css


### PR DESCRIPTION
IIFE which returns `this`, returns global object.
if it is node, global object is not `window`.
but in node, we can create `window` and add it to global object.
so, browser and node may have `window` property.

p.s. I need baron in node for tests.